### PR TITLE
C-Beam Linear Rail

### DIFF
--- a/linear_rails/cbeam.scad
+++ b/linear_rails/cbeam.scad
@@ -1,0 +1,102 @@
+use <MCAD/shapes.scad>;
+include <../utils/colors.scad>;
+
+module cbeam(length=50, finish=color_aluminum) {
+
+  size = 20;
+
+  cutext=[[0.00, 5.43], [4.57, 10.00], [4.57, 10.10], [-4.57, 10.10], [-4.57, 10.00]];
+  cutint=[[-2.84, 3.90], [-0.21, 3.90], [0.00, 3.70], [0.21, 3.90], [2.84, 3.90], [5.50, 6.56], [5.50, 8.20], [2.89, 8.20], [2.89, 9.20], [-2.89, 9.20], [-2.89, 8.20], [-5.50, 8.20], [-5.50, 6.56]];
+
+  cut_big =
+    [[6.1, -2.84],
+     [6.1, -0.21],
+     [6.3, 0],
+     [6.1, 0.21],
+     [6.1, 2.84],
+     [2.7, 6.2],
+     [2.7, 8.2],
+     [-0.1, 8.2],
+     [-0.1, -8.2],
+     [2.7, -8.2],
+     [2.7, -6.2]];
+
+  cut_big_corner =
+    [[6.1, -2.84],
+     [6.1, -0.21],
+     [6.3, 0],
+     [6.1, 0.21],
+     [6.1, 2.84],
+     [0.739, 8.2],
+     [-0.1, 8.2],
+     [-0.1, -8.2],
+     [2.7, -8.2],
+     [2.7, -6.2]];
+
+  color(finish)
+  translate([0, 0, length/2]) difference(convexity=16) {
+
+    // Stock
+    union() {
+      roundedBox(size*4, size, length, 1.8);
+      for (x = [-30, 30])
+        translate([x, 20, 0])
+          roundedBox(size, size, length, 1.8);
+      for (x = [-30, 30])
+        translate([x, 10, 0])
+          cube([size, size/2, length], center=true);
+    }
+
+    // Screw holes
+    for (section = [[-1, 0],
+                    [-2, 0],
+                    [-2, 1],
+                    [1, 0],
+                    [2, 0],
+                    [2, 1]]) {
+      translate([section[0]*size-sign(section[0])*size/2, section[1]*size, 0])
+        cylinder(d=4.2, h=length+2, center=true);
+    }
+
+    // Interior cuts
+    translate([0, 0, -length/2-1]) {
+      linear_extrude(length + 2, convexity=8) {
+
+        polygon(cut_big);
+        mirror([1, 0]) polygon(cut_big);
+
+        interior_half();
+        mirror([1, 0]) interior_half();
+
+      }
+    }
+  }
+
+  module interior_half() {
+
+    translate([size, 0]) {
+      polygon(cut_big_corner);
+      mirror([1, 0]) polygon(cut_big);
+    }
+
+    translate([size*1.5, size/2]) rotate(90) {
+      polygon(cut_big);
+      mirror([1, 0]) polygon(cut_big_corner);
+    }
+
+    translate([size/2, 0]) {
+      mirror([0, 1]) { polygon(cutext); polygon(cutint); }
+      polygon(cutext); polygon(cutint);
+    }
+
+    translate([size*1.5, 0]) {
+      mirror([0, 1]) { polygon(cutext); polygon(cutint); }
+      translate([0, size]) { polygon(cutext); polygon(cutint); }
+    }
+
+    translate([size*1.5, 0]) rotate(270) { polygon(cutext); polygon(cutint); }
+    translate([size*1.5, size]) rotate(270) { polygon(cutext); polygon(cutint); }
+    translate([size*1.5, size]) rotate(90) { polygon(cutext); polygon(cutint); }
+
+  }
+}

--- a/linear_rails/vslot.scad
+++ b/linear_rails/vslot.scad
@@ -6,7 +6,6 @@ module vslot(length=50, sections=1, finish) {
   cutext=[[0.00, 5.43], [4.57, 10.00], [4.57, 10.10], [-4.57, 10.10], [-4.57, 10.00]];
   cutint=[[-2.84, 3.90], [-0.21, 3.90], [0.00, 3.70], [0.21, 3.90], [2.84, 3.90], [5.50, 6.56], [5.50, 8.20], [2.89, 8.20], [2.89, 9.20], [-2.89, 9.20], [-2.89, 8.20], [-5.50, 8.20], [-5.50, 6.56]];
   cutintin=[[-2.84, 3.90], [-0.21, 3.90], [0.00, 3.70], [0.21, 3.90], [2.84, 3.90], [6.20, 7.30], [8.20, 7.30], [8.20, 10.10], [-8.20, 10.10], [-8.20, 7.30], [-6.20, 7.30]];
-  cutint2=[[8.20, 8.20], [6.57, 8.20], [6.57, 7.62], [7.62, 6.57], [8.20, 6.57]];
 
   module profile() {
     translate([0, 0, length/2]) difference() {
@@ -21,9 +20,6 @@ module vslot(length=50, sections=1, finish) {
             translate([offset, 0, -(total_length)/2]) linear_extrude(total_length) rotate(angle) polygon(cutint);
           } else {
             translate([offset, 0, -(total_length)/2]) linear_extrude(total_length) rotate(angle) polygon(cutintin);
-          }
-          if ((section==0 && (angle==90 || angle==180)) || (section==sections-1 && (angle==0 || angle==270))) {
-            translate([offset, 0, -(total_length)/2]) linear_extrude(total_length) rotate(angle) polygon(cutint2);
           }
         }
       }


### PR DESCRIPTION
Add a simple module `cbeam(length, finish)` to generate [OpenBuilds C-Beam linear rail](https://openbuildspartstore.com/c-beam-linear-rail/). C-Beam is basically a '[' shaped arrangement of V-Slot 20x80 and 20x20 linear rail and this code is heavily derived from the `vslot()` module. However, the interior shafts in the corners have slightly different shaping in order to support the concave corners of the '[', which is reflected by this module.

In addition, based on photos, OpenBuilds' V-Slot extrusions seems to not actually have the small corner shafts included on some of their engineering models & drawings, captured by `cutint2` in `vslot()`. These have also been removed from the V-Slot and C-Beam modules in this PR.